### PR TITLE
Misconfiguration prevents mod from working

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
 mixin {
-    add sourceSets.main, "sheepconsistencyforge.mixins.json"
+    add sourceSets.main, "sheepconsistencyforge.refmap.json"
 }
 
 
@@ -97,6 +97,8 @@ minecraft {
 
         data {
             workingDirectory project.file('run')
+            properties 'mixin.env.remapRefMap': 'true'
+            property 'mixin.env.refMapRemappingFile', "${project.projectDir}/build/createSrgToMcp/output.srg"
 
             // Recommended logging data for a userdev environment
             // The markers can be changed as needed. 
@@ -109,6 +111,7 @@ minecraft {
             // You can set various levels here.
             // Please read: https://stackoverflow.com/questions/2031163/when-to-use-the-different-log-levels
             property 'forge.logging.console.level', 'debug'
+
 
             // Specify the modid for data generation, where to output the resulting resource, and where to look for existing resources.
             args '--mod', 'sheepconsistencyforge', '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')

--- a/src/main/java/me/jsb/sheepconsistencyforge/SheepConsistencyForge.java
+++ b/src/main/java/me/jsb/sheepconsistencyforge/SheepConsistencyForge.java
@@ -1,10 +1,11 @@
 package me.jsb.sheepconsistencyforge;
 
+import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 
 // The value here should match an entry in the META-INF/mods.toml file
 @Mod(SheepConsistencyForge.MOD_ID)
-public class SheepConsistencyForge{
+public class SheepConsistencyForge {
 	
 	public static final String MOD_ID = "sheepconsistencyforge";
 }

--- a/src/main/java/me/jsb/sheepconsistencyforge/client/SheepShearedLayerRenderer.java
+++ b/src/main/java/me/jsb/sheepconsistencyforge/client/SheepShearedLayerRenderer.java
@@ -20,7 +20,7 @@ public class SheepShearedLayerRenderer extends LayerRenderer<SheepEntity, SheepM
 	}
 	
 	@Override
-	   public void render(MatrixStack matrixStack, IRenderTypeBuffer vertexConsumerProvider, int i, SheepEntity sheepEntity, float f, float g, float h, float j, float k, float l) {
+    public void render(MatrixStack matrixStack, IRenderTypeBuffer vertexConsumerProvider, int i, SheepEntity sheepEntity, float f, float g, float h, float j, float k, float l) {
         float v;
         float w;
         float x;

--- a/src/main/java/me/jsb/sheepconsistencyforge/mixin/SheepRendererMixin.java
+++ b/src/main/java/me/jsb/sheepconsistencyforge/mixin/SheepRendererMixin.java
@@ -23,7 +23,7 @@ public abstract class SheepRendererMixin extends MobRenderer<SheepEntity, SheepM
 	}
 
 	@Inject(at = @At ("TAIL"), method = "<init>(Lnet/minecraft/client/renderer/entity/EntityRendererManager;)V")
-	private void init(EntityRendererManager dispatcher, CallbackInfo info) {
+	private void sheep_consistency_forge_init(EntityRendererManager dispatcher, CallbackInfo info) {
 		this.addLayer(new SheepShearedLayerRenderer(this));
 	}
 }

--- a/src/main/resources/sheepconsistencyforge.mixins.json
+++ b/src/main/resources/sheepconsistencyforge.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "package": "me.jsb.sheepconsistencyforge.mixin",
   "compatibilityLevel": "JAVA_8",
-  "refmap": "sheepconsistencyforge.mixins.json",
+  "refmap": "sheepconsistencyforge.refmap.json",
   "mixins": [
 	"SheepRendererMixin"
   ],


### PR DESCRIPTION
The Mixin refmap has the same filename as the mixin config, thus the mixin config gets overwritten preventing the mixin from being loaded when compiled and used. 

I made some small build.gradle adjustments to fix it. The mod now loads and works correctly again. 

Thanks for porting the fabric version, it's small but I like it nevertheless. 